### PR TITLE
Adding commas to scale labels

### DIFF
--- a/ChartNew.js
+++ b/ChartNew.js
@@ -930,7 +930,8 @@ window.Chart = function (context) {
         spaceTop: 0,
         spaceBottom: 0,
         spaceRight: 0,
-        spaceLeft: 0
+        spaceLeft: 0,
+		scaleCommas: false
     };
 
     chart.defaults.xyAxisCommonOptions = {


### PR DESCRIPTION
- Adds option to add commas to scale labels
- Defaults to off (`options.scaleCommas = false`)
