### PR TITLE
Broken charts with same value datasets

### DIFF
--- a/ChartNew.js
+++ b/ChartNew.js
@@ -1235,6 +1235,11 @@ window.Chart = function (context) {
                 if (data[i].value < lowerValue) { lowerValue = data[i].value; }
             };
 
+			if (upperValue == lowerValue) {
+				upperValue = upperValue*2;
+				lowerValue = 0;
+			}
+
             if (!isNaN(config.graphMin)) lowerValue = config.graphMin;
             if (!isNaN(config.graphMax)) upperValue = config.graphMax;
 
@@ -1554,6 +1559,11 @@ window.Chart = function (context) {
                     if (data.datasets[i].data[j] < lowerValue) { lowerValue = data.datasets[i].data[j] }
                 }
             }
+
+			if (upperValue == lowerValue) {
+				upperValue = upperValue*2;
+				lowerValue = 0;
+			}
 
             if (!isNaN(config.graphMin)) lowerValue = config.graphMin;
             if (!isNaN(config.graphMax)) upperValue = config.graphMax;
@@ -2048,6 +2058,11 @@ window.Chart = function (context) {
                     if (data.datasets[i].data[j] < lowerValue) { lowerValue = data.datasets[i].data[j] };
                 }
             };
+
+			if (upperValue == lowerValue) {
+				upperValue = upperValue*2;
+				lowerValue = 0;
+			}
 
             // AJOUT CHANGEMENT
             if (!isNaN(config.graphMin)) lowerValue = config.graphMin;
@@ -2807,6 +2822,11 @@ window.Chart = function (context) {
                     if (data.datasets[i].data[j] < lowerValue) { lowerValue = data.datasets[i].data[j] };
                 }
             };
+
+			if (upperValue == lowerValue) {
+				upperValue = upperValue*2;
+				lowerValue = 0;
+			}
 
             // AJOUT CHANGEMENT
             if (!isNaN(config.graphMin)) lowerValue = config.graphMin;


### PR DESCRIPTION
I've noticed your fork has the same bug the original has. If you have a dataset where all the values are the same then bar, line, radar and polarArea charts are either completely blank or have visible axes and labels but are missing the actual data.  

Here is an example of bar and line charts, where all the values are the same:
![chart-missing](https://f.cloud.github.com/assets/3016935/2365310/6ea0c2be-a6bb-11e3-9332-58507f8ae45e.png)

And this is what I would expect to get (after my bugfix):
![chart-fixed](https://f.cloud.github.com/assets/3016935/2365311/78100c38-a6bb-11e3-807a-805fea033a84.png)
