### PR TITLE
Multiple doughnuts of different sizes.

### DIFF
--- a/ChartNew.js
+++ b/ChartNew.js
@@ -2234,7 +2234,7 @@ window.Chart = function (context) {
 
     var Doughnut = function (data, config, ctx) {
         var segmentTotal = 0;
-        var msr, midPieX, midPieY;
+        var msr, midPieX, midPieY, doughnutRadius;
 
         if (!dynamicFunction(data,config,ctx,"Doughnut"))return;
         


### PR DESCRIPTION
So, in using this library. I was trying to run multiple instances of `Chart.Doughnut()` at different sizes, and for some reason, when a larger doughnut came on screen, it made the smaller ones bigger inside their smaller canvas size.

After wayyy to much egg chasing, I found that the doughnutRadius variable was never defined, thus in the global namespace. Therefore, if two different Doughnuts appeared at different sizes, the bigger one would change the global `doughnutRadius` variable, and then the smaller Doughnut would grow to use the bigger Doughnuts `doughnutRadius` size. 

This pull request is simple, it defines a `doughnutRadius` for each `Chart.Doughnut()` Alleviating this issue.
