### PR TITLE
Error handling for issues with multiple charts and annotations

### DIFF
--- a/ChartNew.js
+++ b/ChartNew.js
@@ -587,8 +587,7 @@ annotateDIV.style.display = show ? '' : 'none';
  
 
 //Define the global Chart Variable as a class.
-window.Chart = function (context) {
-    if (!context.canvas.id) throw new Error('CHART ERROR: Your canvas must have an id associated to it.')
+window.Chart = function (context){
 
     var chart = this;
 
@@ -2234,6 +2233,8 @@ window.Chart = function (context) {
     } ;
 
     var Doughnut = function (data, config, ctx) {
+    	if (!ctx.canvas.id && config.annotateDisplay) throw new Error('CHART ERROR: You must have an ID on your chart to use annotateDisplay');
+    	
         var segmentTotal = 0;
         var msr, midPieX, midPieY, doughnutRadius;
 


### PR DESCRIPTION
So, I found out when using this that the annotations store in a array that all chart instances use, and searches through the array by the canvas ID. So here is the bug:

When you utilize multiple charts, and they are all annotating. If you don't set an ID on the canvas, then essentially the id is an empty string. And every chart with no id over-writes the previous jsGraphAnnotate key with an empty string. 

So given a situation where you have three charts with no id's. The internal annotate data would look something like this:

`jsGraphAnnotate = {" ": .....}`

instead of something like:

`jsGraphAnnotate = {id1: ....., id2: ......, id3: .......}`

So this pull request is a super simple way of just telling the user they must put an ID on the canvas element. So we could do this. Or, we could change the way the internals work. Have a tracking internal id for each chart when it gets created, and store things via that rather than the canvas.id if we dont want to force implementors to set an ID. 

I'm up for either. I'll do the code change if we want the other way. Or if an error is enough, or another idea is better. Whatever works.
