### PR TITLE
Break line in line chart when there is no data. #112

### DIFF
--- a/ChartNew.js
+++ b/ChartNew.js
@@ -5547,6 +5547,7 @@ window.Chart = function (context) {
 					        ctx.restore();
 					     }
 				  }
+	  }
 				} else {
 	if(false  == config.extrapolateMissingData)
                     {


### PR DESCRIPTION
ticket : https://github.com/FVANCOP/ChartNew.js/issues/112

in order to break the lines instead of extrapolating the missing data this option has to be added. By default it is set to true.

extrapolateMissingData : false,
