### PR TITLE
Second fix for issue 238

### DIFF
--- a/ChartNew.js
+++ b/ChartNew.js
@@ -758,7 +758,7 @@ function doMouseAction(config, ctx, event, data, action, funct) {
 						x = bw.ns4 || bw.ns5 ? event.pageX : event.x;
 						y = bw.ns4 || bw.ns5 ? event.pageY : event.y;
 						if (bw.ie4 || bw.ie5) y = y + eval(scrolled);
-						if(x+fromLeft+textMsr.textWidth > window.innerWidth-rect.left-10) oCursor.moveIt(x + fromLeft-textMsr.textWidth, y + fromTop);
+						if(config.annotateRelocate && x+fromLeft+textMsr.textWidth > window.innerWidth-rect.left-10) oCursor.moveIt(x + fromLeft-textMsr.textWidth, y + fromTop);
 						else oCursor.moveIt(x + fromLeft, y + fromTop);
 					}
 				}
@@ -783,7 +783,7 @@ function doMouseAction(config, ctx, event, data, action, funct) {
 					x = bw.ns4 || bw.ns5 ? event.pageX : event.x;
 					y = bw.ns4 || bw.ns5 ? event.pageY : event.y;
 					if (bw.ie4 || bw.ie5) y = y + eval(scrolled);
-					if(x+fromLeft+textMsr.textWidth > window.innerWidth-rect.left-10) oCursor.moveIt(x + fromLeft-textMsr.textWidth, y + fromTop);
+					if(config.annotateRelocate && x+fromLeft+textMsr.textWidth > window.innerWidth-rect.left-10) oCursor.moveIt(x + fromLeft-textMsr.textWidth, y + fromTop);
 					else oCursor.moveIt(x + fromLeft, y + fromTop);
 				}
 			}
@@ -827,7 +827,7 @@ function doMouseAction(config, ctx, event, data, action, funct) {
 					x = bw.ns4 || bw.ns5 ? event.pageX : event.x;
 					y = bw.ns4 || bw.ns5 ? event.pageY : event.y;
 					if (bw.ie4 || bw.ie5) y = y + eval(scrolled);
-					if(x+fromLeft+textMsr.textWidth > window.innerWidth-rect.left-10) oCursor.moveIt(x + fromLeft-textMsr.textWidth, y + fromTop);
+					if(config.annotateRelocate && x+fromLeft+textMsr.textWidth > window.innerWidth-rect.left-10) oCursor.moveIt(x + fromLeft-textMsr.textWidth, y + fromTop);
 					else oCursor.moveIt(x + fromLeft, y + fromTop);
 				}
 			}
@@ -1584,6 +1584,7 @@ window.Chart = function(context) {
 		legendXPadding : 0,
 		legendYPadding : 0,
 		annotateDisplay: false,
+		annotateRelocate: false,
 		savePng: false,
 		savePngOutput: "NewWindow", // Allowed values : "NewWindow", "CurrentWindow", "Save"
 		savePngFunction: "mousedown right",

--- a/Samples/div_in_annotate.html
+++ b/Samples/div_in_annotate.html
@@ -1,0 +1,69 @@
+<!doctype html>
+
+<style>
+#inner {
+    width: 50%;
+    margin: 0 auto;
+    background-color:#b0c4de;
+}
+</style>
+
+<!--[if lte IE 8]><SCRIPT src='source/excanvas.js'></script><![endif]--><SCRIPT src='../ChartNew.js'></script>
+
+
+<SCRIPT>
+
+defCanvasWidth=1200;
+defCanvasHeight=600;
+
+var mydata1 = {
+	labels : ["January","February","March","April","May","June","July"],
+	datasets : [
+		{
+			fillColor : "rgba(220,220,220,0.5)",
+			strokeColor : "rgba(220,220,220,1)",
+			pointColor : "rgba(220,220,220,1)",
+			pointStrokeColor : "#fff",
+			data : [65,59,90,81,56,55,30],
+      title : "pFirst data"
+		},
+		{
+			fillColor : "rgba(151,187,205,0.5)",
+			strokeColor : "rgba(151,187,205,1)",
+			pointColor : "rgba(151,187,205,1)",
+			pointStrokeColor : "#fff",
+			data : [28,48,20,19,46,27,110],
+      title : "pSecond data"
+		}
+	]
+}
+
+var newopts = {
+      inGraphDataShow : true,
+      canvasBorders : true,
+      canvasBordersWidth : 3,
+      canvasBordersColor : "black",
+      annotateDisplay : true, 
+      annotateLabel : "<%='This div tag<div id=\"inner\">This is the included div</div>'%>"
+}
+
+</SCRIPT>
+
+<html>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+<head>
+<title>Demo ChartNew.js</title>
+</head>
+<body>
+   
+<center>
+    <FONT SIZE=6><B>Demo of ChartNew.js !</B></FONT>    <BR>
+    <script>
+	document.write("<canvas id=\"canvas_bar\" height=\""+defCanvasHeight+"\" width=\""+defCanvasWidth+"\"></canvas>");
+	window.onload = function() {
+	var myCanvas = new Chart(document.getElementById("canvas_bar").getContext("2d")).Bar(mydata1,newopts);
+	}
+    </script>
+</center>
+</body>
+</html>


### PR DESCRIPTION
A problem reported in issue #240 : in some cases, the annotate is displayed far from the mouse. This problem has been introduced by the fix for issue #238.

In order to avoid the problem reported in issue #240, an new option has been defined : "annotateRelocate"; Default value is false; Set it to true it you want to avoid problem reported in issue #238 (in first fix, the annotate relocation was always performed, but it is not correct).

